### PR TITLE
fix: handles nil operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zhevron/gqlgen-opentelemetry/v2
+module github.com/withtally/gqlgen-opentelemetry/v2
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/withtally/gqlgen-opentelemetry/v2
+module github.com/zhevron/gqlgen-opentelemetry/v2
 
 go 1.16
 

--- a/tracer.go
+++ b/tracer.go
@@ -48,6 +48,9 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 		return next(ctx)
 	}
 	oc := graphql.GetOperationContext(ctx)
+	if oc.Operation == nil  {
+		return next(ctx)
+	}
 	operationType := getOperationTypeAttribute(oc)
 	spanName := makeSpanName(oc.Operation.Name, operationType.Value.AsString())
 	ctx, span := t.getTracer(ctx).Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindServer), trace.WithAttributes(baseAttributes...))


### PR DESCRIPTION
it seems when there is a GraphQL syntax error, there is no `Operation` in the context. The `ctx.value` evaluates to `OperationContext` but the actual `Operation` is missing/not populated