### PR TITLE
fix: typo triggers panic in certain scenarios

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -61,7 +61,7 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 		semconv.GraphqlDocument(oc.RawQuery),
 	)
 	if operationName != "" {
-		span.SetAttributes(semconv.GraphqlOperationName(oc.Operation.Name))
+		span.SetAttributes(semconv.GraphqlOperationName(operationName))
 	}
 	if stats := extension.GetComplexityStats(ctx); stats != nil {
 		span.SetAttributes(graphqlComplexity.Int(stats.Complexity))

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -115,13 +115,13 @@ func (s *TracerSuite) TestQuery_ParsingError() {
 
 	query := "query GetGreeting { greeting"
 	var res struct{ Greeting string }
-	s.Require().Error(c.Post(query, &res))
+	s.Require().Error(c.Post(query, &res, func(req *client.Request) { req.OperationName = "GetGreeting" }))
 
 	spans := s.Exporter.GetSpans()
 	s.Require().Len(spans, 1)
 	s.Require().Equal("GraphQL Operation", spans[0].Name)
 	s.Require().Equal(codes.Error, spans[0].Status.Code)
-	s.Require().Len(spans[0].Attributes, 3)
+	s.Require().Len(spans[0].Attributes, 4)
 }
 
 func (s *TracerSuite) TestMutation_SpanCreated() {


### PR DESCRIPTION
A prior merge (https://github.com/zhevron/gqlgen-opentelemetry/pull/74) has a typo that hides an error (the nil check is against `operationName`, whereas the access is on `oc.Operation.Name`).
Fixed the UT as well to actually inject an operation name.